### PR TITLE
Add support for /EH switch

### DIFF
--- a/CClash/Compiler.cs
+++ b/CClash/Compiler.cs
@@ -497,12 +497,14 @@ namespace CClash
                             }
                             break;
 
+                        case "/E":
+                            return NotSupported(opt);
+
+                        case "/EP":
+                            return NotSupported(opt);
+
                         default:
                             #region positional or other flag options
-                            if (full.StartsWith("/E"))
-                            {
-                                return NotSupported("/E");
-                            }
 
                             if (full == "/link")
                             {


### PR DESCRIPTION
Instead of wildcard marking /E\* as unsupported,
only reject /E and /EP. Fixes issue #5.

Signed-off-by: Marat Radchenko marat@slonopotamus.org
