### PR TITLE
The /Fd option do not generate a pdb file

### DIFF
--- a/CClash/Compiler.cs
+++ b/CClash/Compiler.cs
@@ -465,7 +465,6 @@ namespace CClash
                             break;
 
                         case "/Fd":
-                            GeneratePdb = true;
                             PdbFile = Path.Combine(WorkingDirectory, full.Substring(3));
                             // openssl gives us a posix path here..
                             PdbFile = PdbFile.Replace('/', '\\');


### PR DESCRIPTION
It just tells where to store it when it is generated, GeneratePdb should not be set to true whith this option
Fix the issue #9 
