### PR TITLE
Do not append .pdb to pdb-paths ending in a backslash

### DIFF
--- a/CClash/Compiler.cs
+++ b/CClash/Compiler.cs
@@ -469,7 +469,7 @@ namespace CClash
                             PdbFile = Path.Combine(WorkingDirectory, full.Substring(3));
                             // openssl gives us a posix path here..
                             PdbFile = PdbFile.Replace('/', '\\');
-                            if (!PdbFile.ToLower().EndsWith(".pdb"))
+                            if (!PdbFile.ToLower().EndsWith(".pdb") && !PdbFile.EndsWith("\\"))
                             {
                                 PdbFile = PdbFile + ".pdb";
                             }


### PR DESCRIPTION
So far cclash doesn't work properly for pdb paths of the form
  `/Fdpath\to\pdbfile\`
as it translates this into
  `/Fdpath\to\pdbfile\.pdb`
which cl.exe does not understand. 

This fix stops cclash from modifying the pdb path in such cases.