### PR TITLE
Process output directory correctly if specified

### DIFF
--- a/CClash.Tests/CompilerTest.cs
+++ b/CClash.Tests/CompilerTest.cs
@@ -66,7 +66,7 @@ namespace CClash.Tests
         [Test]
         [TestCase("/c","test-sources\\exists.c")]
         [TestCase("/c","test-sources\\exists.c", "/Fowhatever.obj")]
-        [TestCase("/c","test-sources\\exists.c", "/Fotest-sources")]
+        [TestCase("/c","test-sources\\exists.c", "/Fotest-sources\\")]
         public void ParseSupportedArgs(params string[] argv)
         {
             var c = new Compiler();

--- a/CClash/Compiler.cs
+++ b/CClash/Compiler.cs
@@ -475,8 +475,9 @@ namespace CClash
                             break;
 
                         case "/Fo":
-                            ObjectTarget = Path.Combine(WorkingDirectory, full.Substring(3));
-                            if (!Path.GetFileName(ObjectTarget).Contains("."))
+                            var option = full.Substring(3).Replace('/', '\\');
+                            ObjectTarget = Path.Combine(WorkingDirectory, option);
+                            if (!Path.GetFileName(ObjectTarget).Contains(".") && !option.EndsWith("\\"))
                                 ObjectTarget += ".obj";
                             break;
 
@@ -601,6 +602,11 @@ namespace CClash
                         {
                             ObjectTarget = Path.Combine(WorkingDirectory, f);
                         }
+                    }
+                    // output option is a directory:
+                    else if (ObjectTarget.EndsWith("\\"))
+                    {
+                        ObjectTarget = Path.Combine(ObjectTarget, Path.GetFileNameWithoutExtension(SingleSourceFile) + ".obj");
                     }
 
                     if (GeneratePdb)


### PR DESCRIPTION
Similar to https://github.com/inorton/cclash/pull/11, except it handles '/' or '\', and I modified a unit test to properly test the output directory.