### PR TITLE
Fix hashcache item overwrite

### DIFF
--- a/CClash/CompilerCacheBase.cs
+++ b/CClash/CompilerCacheBase.cs
@@ -124,7 +124,14 @@ namespace CClash
         public DataHash DeriveHashKey( ICompiler comp, IEnumerable<string> args)
         {
             Logging.Emit("compiler is {0}", comp.CompilerExe);
-            var comphash = DigestCompiler(comp.CompilerExe);
+            var tmp = DigestCompiler(comp.CompilerExe);
+            var comphash = new DataHash()
+            {
+                InputName = tmp.InputName,
+                Result = tmp.Result,
+                Hash = tmp.Hash,
+            };
+
             if (comphash.Result == DataHashResult.Ok)
             {
                 var buf = new StringWriter();


### PR DESCRIPTION
A have always cache miss, caused by incorrect compiler hash changes for every call. I think it broken since
https://github.com/inorton/cclash/commit/7ff6fb5aeb2c8919f042e6b217201e40bfc9b821#diff-83eec8d21b1df0bc376301b934145bf3L145
DigestCompiler returns hash for cl.exe by reference and we orerwrite it in L156.
I don't know how right fix it in C#, but put my hotfix here.